### PR TITLE
修改Cosplayer翻译为偶像

### DIFF
--- a/src/services/tagging.ts
+++ b/src/services/tagging.ts
@@ -118,7 +118,7 @@ export class Tagging {
     readonly namespaceTranslate: Record<EHTNamespaceName, string> = {
         rows: '行名',
         artist: '艺术家',
-        cosplayer: 'Coser',
+        cosplayer: '偶像',
         parody: '原作',
         character: '角色',
         group: '团队',

--- a/src/services/ui-translation/data/common.ts
+++ b/src/services/ui-translation/data/common.ts
@@ -61,7 +61,7 @@ merge(
         'character:': '角色：',
         'group:': '社团：',
         'artist:': '艺术家：',
-        'cosplayer:': 'Coser：',
+        'cosplayer:': '偶像：',
         'female:': '女性：',
         'male:': '男性：',
         'mixed:': '混合：',

--- a/src/services/ui-translation/data/uconfig.ts
+++ b/src/services/ui-translation/data/uconfig.ts
@@ -85,7 +85,7 @@ merge(/^\/uconfig\.php/, undefined, {
     ' character': ' 角色',
     ' group': ' 社团',
     ' artist': ' 艺术家',
-    ' cosplayer': ' Coser',
+    ' cosplayer': ' 偶像',
     ' male': ' 男性',
     ' female': ' 女性',
     ' mixed': ' 混合',


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5716100/173187516-d2deead2-09ae-4b3c-bc77-5eadbba2a47d.png)
> 偶像（アイドル，Idol），是一种职业或身份，也是对艺人的一种称呼。 是指从事演艺方面事业，通过展现个人魅力而受到年轻人崇拜与追捧的对象。 同时，偶像也是ACGN次文化中的萌属性之一。

主要看起来比较整齐.

sankaku的真人图库使用的idol作为域名, idol.sankakucomplex.com

你们怎么看? @OpportunityLiu @Mapaler 