### PR TITLE
Support Web Extension V3

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,10 +1,10 @@
 {
-    "manifest_version": 2,
+    "manifest_version": 3,
     "description": "E 站注射器，将中文翻译注入到 E 站体内。包含全站 UI 翻译和超过 33000 条标签翻译，标签数据库持续更新中。",
-    "__firefox__applications": {
+    "__firefox__browser_specific_settings": {
         "gecko": {
             "id": "{759d5566-1dce-41ae-bae9-00dd5172c422}",
-            "strict_min_version": "57.0"
+            "strict_min_version": "106.0"
         }
     },
     "icons": {
@@ -17,9 +17,10 @@
         "keyword": "ex"
     },
     "background": {
-        "scripts": ["script/background.js"]
+        "__chrome__service_worker": "script/background.js",
+        "__firefox__scripts": ["script/background.js"]
     },
-    "browser_action": {
+    "action": {
         "default_icon": {
             "32": "assets/logo32.png",
             "16": "assets/logo16.png",
@@ -44,11 +45,8 @@
             "run_at": "document_start"
         }
     ],
-    "permissions": [
-        "activeTab",
-        "notifications",
-        "storage",
-        "contextMenus",
+    "permissions": ["activeTab", "notifications", "storage", "contextMenus"],
+    "host_permissions": [
         "*://exhentai.org/*",
         "*://exhentai55ld2wyap5juskbm67czulomrouspdacjamjeloj7ugjbsad.onion/*",
         "*://e-hentai.org/*",

--- a/src/providers/web-ext/menu.ts
+++ b/src/providers/web-ext/menu.ts
@@ -7,13 +7,16 @@ export function createMenu(info: Menu): void {
         return;
     }
     browser.contextMenus.create({
+        id: info.title,
         title: info.title,
         targetUrlPatterns: info.targetUrlPatterns,
         contexts: info.contexts,
-        onclick: (data: Menus.OnClickData): void => {
-            info.onclick({
-                url: data.mediaType ? data.srcUrl : data.linkUrl,
-            });
-        },
+    });
+    browser.contextMenus.onClicked.addListener((data: Menus.OnClickData): void => {
+        if (data.menuItemId !== info.title) return;
+
+        info.onclick({
+            url: data.mediaType ? data.srcUrl : data.linkUrl,
+        });
     });
 }

--- a/src/providers/web-ext/utils.ts
+++ b/src/providers/web-ext/utils.ts
@@ -31,16 +31,16 @@ export function sendNotification(info: NotificationInfo): void {
 }
 
 export function setBadge(info: Badge): void {
-    if (info.background && chrome.browserAction.setBadgeBackgroundColor) {
-        void chrome.browserAction.setBadgeBackgroundColor({ color: info.background });
+    if (info.background && typeof chrome.action.setBadgeBackgroundColor == 'function') {
+        void chrome.action.setBadgeBackgroundColor({ color: info.background });
     }
     if (info.text != null) {
-        if (chrome.browserAction.setBadgeText) {
-            void chrome.browserAction.setBadgeText({ text: info.text });
-        } else if (chrome.browserAction.setTitle) {
+        if (typeof chrome.action.setBadgeText == 'function') {
+            void chrome.action.setBadgeText({ text: info.text });
+        } else if (typeof chrome.action.setTitle == 'function') {
             const extname = packageJson.displayName;
             const title = info.text ? `${extname} (${info.text})` : extname;
-            void chrome.browserAction.setTitle({ title });
+            void chrome.action.setTitle({ title });
         }
     }
 }


### PR DESCRIPTION
Fix #813 

## 相关文档

Chrome 迁移指南：https://developer.chrome.com/docs/extensions/mv3/intro/mv3-migration/
Chrome 博客：https://developer.chrome.com/blog/mv2-transition/
Chrome 时间线：https://developer.chrome.com/docs/extensions/mv3/mv2-sunset/
FF 迁移指南：https://extensionworkshop.com/documentation/develop/manifest-v3-migration-guide/
FF 博客：https://blog.mozilla.org/addons/2022/05/18/manifest-v3-in-firefox-recap-next-steps/

## 时间线

- 2020/12/9：Chrome 发布 V3
- 2022/1/17：Chrome 标记 V2 过时
- 2022/12：Firefox 支持 V3，关于 background service worker 支持暂无时间表
- 2024/6：Chrome 关闭 V2 开关
- 2024/6+x：Chrome 停止支持 V2
