### PR TITLE
添加图片浏览界面的exclude防止遮挡eHunter页码

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -39,7 +39,13 @@
                 "*://*.e-hentai.org/*",
                 "*://*.hath.network/*"
             ],
-            "exclude_matches": ["*://forums.e-hentai.org/*"],
+            "exclude_matches": [
+                "*://forums.e-hentai.org/*",
+                "*://exhentai.org/s/*",
+                "*://*.exhentai.org/s/*",
+                "*://e-hentai.org/s/*",
+                "*://*.e-hentai.org/s/*"
+            ],
             "js": ["script/page.js"],
             "run_at": "document_start"
         }


### PR DESCRIPTION
右下角的设置图标会在使用 eHunter 时遮挡页码，因此添加了 exclude 使得该扩展不会在浏览具体图片时生效，本来浏览具体图片时也不会显示 tag 所以对于功能并无影响。